### PR TITLE
ci: Ignore unexploitable TechDocs vulnerability

### DIFF
--- a/.github/workflows/backstage-techdocs.yml
+++ b/.github/workflows/backstage-techdocs.yml
@@ -77,6 +77,10 @@ jobs:
           output-format: table
           only-fixed: true
           severity-cutoff: critical
+      - name: Upload Grype scan SARIF report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}          
       - name: Test image
         run: |
           docker run --rm localhost:5000/moving-shock/backstage-techdocs:test

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,2 @@
+ignore:
+  - vulnerability: GHSA-pppg-cpfq-h7wr

--- a/backstage-techdocs/VERSION
+++ b/backstage-techdocs/VERSION
@@ -1,2 +1,2 @@
 # renovate: datasource=npm depName=@techdocs/cli
-1.8.22-next.1
+1.8.21


### PR DESCRIPTION
- Revert TechDocs to release version
- Add scan upload